### PR TITLE
Add extra latency value to response object

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -101,6 +101,7 @@ Monitor.prototype.ping = function () {
 
     if(self.website.indexOf('https:') === 0) {
         req = https.request(options, function (res) {
+            self.latency = Date.now() - currentTime;
 
             // Website is up
             if (res.statusCode === 200) {
@@ -114,6 +115,7 @@ Monitor.prototype.ping = function () {
     }
     else {
         req = http.request(options, function (res) {
+            self.latency = Date.now() - currentTime;
 
             // Website is up
             if (res.statusCode === 200) {
@@ -168,7 +170,8 @@ Monitor.prototype.responseData = function (statusCode, msg) {
         website: this.website,
         time: Date.now(),
         statusCode: statusCode,
-        statusMessage: msg
+        statusMessage: msg,
+        latency: this.latency
     };
 
     return data;


### PR DESCRIPTION
This PR simply adds a new `latency` property to the `Monitor` class. It adds this value to the `res` object passed back from `responseData`.

I had a use case where I wanted to know how long each request took, so I added the three lines to do it. Hope it's useful to someone!